### PR TITLE
HCP has been GA

### DIFF
--- a/rosa-workshop/rosa/18-deploy_hcp.md
+++ b/rosa-workshop/rosa/18-deploy_hcp.md
@@ -2,8 +2,6 @@ In this section we will deploy a ROSA cluster using Hosted Control Planes (HCP).
 
 In short, with ROSA HCP you can decouple the control plane from the data plane (workers).  This is a new deployment model for ROSA in which the control plane is hosted in a Red Hat owned AWS account.  Therefore the control plane is no longer hosted in your AWS account thus reducing your AWS infrastructure expenses. The control plane is dedicated to a single cluster and is highly available. See the documentation for more about [Hosted Control Planes](https://docs.openshift.com/rosa/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html).
 
-!!! important
-    As of this writing Hosted Control Planes (HCP) is currently a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. 
 
 ## Prerequisites
 


### PR DESCRIPTION
HCP has been GA, reference https://www.redhat.com/en/blog/red-hat-openshift-service-aws-hosted-control-planes-now-available

This PR remove the tech preview notes.

